### PR TITLE
Improve spacing and mobile readability

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -3,7 +3,19 @@ import { Html, Head, Main, NextScript } from "next/document";
 export default function Document() {
   return (
     <Html lang="en">
-      <Head />
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
+        />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap"
+          rel="stylesheet"
+        />
+      </Head>
       <body className="antialiased">
         <Main />
         <NextScript />

--- a/pages/how-it-works.tsx
+++ b/pages/how-it-works.tsx
@@ -2,8 +2,8 @@ import Link from 'next/link';
 
 export default function HowItWorks() {
   return (
-    <main className="min-h-screen bg-gray-50 py-16">
-      <div className="container mx-auto space-y-12">
+    <main className="min-h-screen bg-gray-50 py-20 md:py-24">
+      <div className="container mx-auto space-y-16 px-4">
         <h1 className="text-4xl font-extrabold text-center">How It Works</h1>
         <ol className="space-y-8 list-decimal list-inside text-lg text-gray-700">
           <li>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -27,24 +27,13 @@ export default function Home() {
           name="description"
           content="Never miss a call—our AI receptionist answers, qualifies, and books your appointments, day or night."
         />
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link
-          rel="preconnect"
-          href="https://fonts.gstatic.com"
-          crossOrigin="true"
-        />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap"
-          rel="stylesheet"
-        />
       </Head>
 
       <main
         className="bg-black text-white font-sans"
-        style={{ fontFamily: 'Poppins, sans-serif' }}
       >
         {/* Hero */}
-        <section className="pt-32 pb-24 px-6 text-center">
+        <section className="pt-36 pb-28 px-6 text-center">
           <h1 className="text-5xl md:text-6xl lg:text-7xl font-bold mb-6 leading-tight">
             Meet Your 24/7 AI Call Caddy
           </h1>
@@ -68,8 +57,8 @@ export default function Home() {
         </section>
 
         {/* Features */}
-        <section className="py-20 px-6 bg-gray-900">
-          <div className="container mx-auto grid gap-10 md:grid-cols-3">
+        <section className="py-24 md:py-32 px-6 bg-gray-900">
+          <div className="container mx-auto grid gap-12 md:grid-cols-3">
             {features.map((f) => (
               <div
                 key={f.title}
@@ -87,7 +76,7 @@ export default function Home() {
         </section>
 
         {/* About / What / How */}
-        <section className="py-20 px-6 bg-black">
+        <section className="py-24 md:py-32 px-6 bg-black">
           <div className="container mx-auto max-w-3xl space-y-16 text-center">
             <div>
               <h2 className="text-3xl md:text-4xl font-bold mb-4">Who We Are</h2>
@@ -126,7 +115,7 @@ export default function Home() {
         </section>
 
         {/* Final CTA */}
-        <section className="py-20 px-6 bg-gray-900">
+        <section className="py-24 md:py-32 px-6 bg-gray-900">
           <div className="container mx-auto text-center">
             <h2 className="text-2xl md:text-3xl font-bold mb-6">
               Ready to elevate your front desk?

--- a/pages/pricing.tsx
+++ b/pages/pricing.tsx
@@ -37,9 +37,9 @@ export default function Pricing() {
   ];
 
   return (
-    <main className="min-h-screen bg-black text-white py-16">
+    <main className="min-h-screen bg-black text-white py-20 md:py-24">
       <h1 className="text-4xl font-extrabold text-center mb-12">Pricing Plans</h1>
-      <div className="container mx-auto grid gap-8 md:grid-cols-4 px-4">
+      <div className="container mx-auto grid gap-12 md:grid-cols-2 lg:grid-cols-4 px-4">
         {plans.map((plan) => (
           <div key={plan.name} className="bg-gray-900 p-6 rounded-lg shadow-lg flex flex-col">
             <h2 className="text-2xl font-semibold mb-2">{plan.name}</h2>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -22,5 +22,6 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: 'Poppins', Arial, Helvetica, sans-serif;
+  line-height: 1.6;
 }


### PR DESCRIPTION
## Summary
- add viewport and font links to document
- apply Poppins globally with better line height
- widen spacing on home, how-it-works and pricing pages
- update page layouts for better mobile experience

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684668c33cb88333b44e79d4279b5836