### PR TITLE
Change industry field to text input

### DIFF
--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -80,11 +80,11 @@ export default function Contact() {
             </label>
             <label className="flex flex-col">
               <span>Industry</span>
-              <select name="industry" className="p-2 rounded bg-gray-200 text-black">
-                <option value="Residential Plumbing">Residential Plumbing</option>
-                <option value="Commercial HVAC">Commercial HVAC</option>
-                <option value="Other">Other</option>
-              </select>
+              <input
+                name="industry"
+                className="p-2 rounded bg-gray-200 text-black"
+                placeholder="e.g. Residential Plumbing"
+              />
             </label>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- replace the industry dropdown in `pages/contact.tsx` with a plain text input

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68469021799483338165867afedbab21