### PR TITLE
Fix mobile spacing of hero buttons

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -45,7 +45,7 @@ export default function Home() {
           </p>
           <div className="flex flex-col sm:flex-row gap-6 justify-center">
             <Link href="/how-it-works">
-              <a className="w-full sm:w-auto px-8 py-4 bg-blue-600 hover:bg-blue-700 rounded-full font-semibold transition">
+              <a className="w-full sm:w-auto px-8 py-4 mb-4 sm:mb-0 bg-blue-600 hover:bg-blue-700 rounded-full font-semibold transition">
                 How It Works
               </a>
             </Link>


### PR DESCRIPTION
## Summary
- add mobile bottom margin to "How It Works" button so it doesn't overlap with "View Pricing"

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684691b2cbd08333bd528e9fc6c4f633