### PR TITLE
Improve mobile design

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -6,7 +6,7 @@ export default function Header() {
   const [menuOpen, setMenuOpen] = useState(false)
   return (
     <header className="fixed top-0 inset-x-0 z-20 backdrop-blur bg-black/60 text-white">
-      <div className="max-w-7xl mx-auto flex items-center justify-between px-6 py-4">
+      <div className="max-w-7xl mx-auto flex items-center justify-between px-4 sm:px-6 py-4">
         <Link href="/">
           <a className="text-xl font-bold">CallCaddy</a>
         </Link>

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -157,7 +157,7 @@ export default function Contact() {
         <p className="text-sm">
           <a href="/terms" className="underline" target="_blank" rel="noopener noreferrer">Terms &amp; Privacy</a>
         </p>
-        <button type="submit" className="px-6 py-3 bg-blue-600 rounded text-white hover:bg-blue-700">Get Started</button>
+        <button type="submit" className="w-full px-6 py-3 bg-blue-600 rounded text-white hover:bg-blue-700">Get Started</button>
       </form>
     </main>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -87,7 +87,7 @@ export default function Home() {
         <section className="pt-40 pb-20 px-6">
           <div className="container mx-auto flex flex-col md:flex-row items-center gap-12">
             <div className="flex-1 text-center md:text-left">
-              <h1 className="text-6xl md:text-7xl font-extrabold mb-6 leading-tight">
+              <h1 className="text-4xl sm:text-6xl md:text-7xl font-extrabold mb-6 leading-tight">
                 Never Miss Another Call
               </h1>
               <p className="text-xl md:text-2xl text-gray-300 mb-8 max-w-xl">
@@ -95,12 +95,12 @@ export default function Home() {
               </p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center md:justify-start">
                 <Link href="/contact">
-                  <a className="px-8 py-4 bg-blue-600 hover:bg-blue-700 rounded-full font-semibold transition shadow">
+                  <a className="w-full sm:w-auto px-8 py-4 text-lg bg-blue-600 hover:bg-blue-700 rounded-full font-semibold transition shadow">
                     Get Started — never miss a lead again!
                   </a>
                 </Link>
                 <Link href="/contact?demo=true">
-                  <a className="px-8 py-4 border border-white hover:bg-white hover:text-black rounded-full font-semibold transition">
+                  <a className="w-full sm:w-auto px-8 py-4 text-lg border border-white hover:bg-white hover:text-black rounded-full font-semibold transition">
                     Book a Demo
                   </a>
                 </Link>
@@ -120,7 +120,7 @@ export default function Home() {
 
         {/* Features */}
         <section className="py-24 md:py-32 px-6 bg-gray-900">
-          <div className="container mx-auto grid gap-12 md:grid-cols-4">
+          <div className="container mx-auto grid gap-12 sm:grid-cols-2 md:grid-cols-4">
             {features.map((f) => (
               <div
                 key={f.title}
@@ -142,7 +142,7 @@ export default function Home() {
         <section className="py-24 md:py-32 px-6 bg-black">
           <div className="container mx-auto text-center">
             <h2 className="text-3xl md:text-4xl font-bold mb-12">How It Works</h2>
-            <div className="grid md:grid-cols-3 gap-8 max-w-4xl mx-auto">
+            <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-8 max-w-4xl mx-auto">
               {steps.map((step) => (
                 <div key={step.text} className="p-6 bg-gray-900 rounded-lg flex flex-col items-center">
                   <step.icon className="w-12 h-12 text-blue-500 mb-4" />
@@ -157,7 +157,7 @@ export default function Home() {
         <section className="py-24 md:py-32 px-6 bg-gray-900">
           <div className="container mx-auto text-center space-y-8">
             <h2 className="text-2xl md:text-3xl font-bold">Why Choose CallCaddy?</h2>
-            <div className="grid md:grid-cols-3 gap-8 max-w-4xl mx-auto">
+            <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-8 max-w-4xl mx-auto">
               {highlights.map((h) => (
                 <div key={h.title} className="p-6 bg-gray-800 rounded-lg flex flex-col items-center text-gray-300">
                   <h.icon className="w-12 h-12 text-blue-500 mb-4" />


### PR DESCRIPTION
## Summary
- tweak hero button layout and heading sizes
- expand responsive grids
- adjust header padding
- widen contact form button for mobile

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6847f4f7e36883338ccee89f9dc538b0