### PR TITLE
Add particles hero background

### DIFF
--- a/components/HeroParticles.tsx
+++ b/components/HeroParticles.tsx
@@ -1,0 +1,43 @@
+import { useCallback } from 'react'
+import Particles from 'react-tsparticles'
+import { loadFull } from 'tsparticles'
+
+export default function HeroParticles() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const particlesInit = useCallback(async (engine: any) => {
+    await loadFull(engine)
+  }, [])
+
+  return (
+    <Particles
+      id="heroParticles"
+      init={particlesInit}
+      className="pointer-events-none absolute inset-0 z-0 w-full h-full"
+      options={{
+        fpsLimit: 30,
+        detectRetina: true,
+        fullScreen: { enable: false },
+        particles: {
+          number: { value: 50 },
+          color: { value: '#ffffff' },
+          opacity: { value: { min: 0.1, max: 0.2 } },
+          shape: { type: 'circle' },
+          size: { value: { min: 2, max: 4 } },
+          move: {
+            enable: true,
+            speed: 0.2,
+            direction: 'none',
+            outModes: { default: 'out' }
+          },
+          links: { enable: false }
+        },
+        interactivity: {
+          events: {
+            onHover: { enable: false },
+            resize: true
+          }
+        }
+      }}
+    />
+  )
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,6 +13,7 @@ import {
   ShieldCheckIcon,
   RocketLaunchIcon,
 } from '@heroicons/react/24/outline'
+import HeroParticles from '@/components/HeroParticles'
 
 
 export default function Home() {
@@ -84,8 +85,9 @@ export default function Home() {
 
       <main className="text-white font-sans">
         {/* Hero */}
-        <section className="pt-40 pb-20 px-6 md:px-8 animate-fadeIn">
-          <div className="container mx-auto flex flex-col md:flex-row items-center gap-12">
+        <section className="relative isolate overflow-hidden bg-[#0f172a] pt-40 pb-20 px-6 md:px-8 animate-fadeIn">
+          <HeroParticles />
+          <div className="relative z-10 container mx-auto flex flex-col md:flex-row items-center gap-12">
             <div className="flex-1 text-center">
               <h1 className="text-4xl sm:text-6xl md:text-7xl font-extrabold mb-6 leading-tight">
                 Never Miss Another Call


### PR DESCRIPTION
## Summary
- create `HeroParticles` component with subtle animated circles
- use `HeroParticles` in the hero section of the home page
- ensure particles render above the section background using `isolate`
- adjust layering so the particles drift visibly behind the hero content

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684806c59bb88333b2954ce11f3800dd