### PR TITLE
Add call & chat links to hero

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -95,13 +95,19 @@ export default function Home() {
               <p className="text-xl md:text-2xl text-gray-300 mb-8 max-w-xl">
                 CallCaddy&apos;s AI receptionist answers instantly, schedules jobs and follows up so you can focus on running your business.
               </p>
-              <div className="flex flex-col sm:flex-row gap-6 justify-center">
-                <Link href="/contact" className="w-full sm:w-auto w-40 text-center px-8 py-5 text-lg bg-blue-600 hover:bg-blue-700 rounded-full font-semibold transition-transform transform hover:scale-105 shadow">
-                  Start Now
-                </Link>
-                <Link href="/contact?demo=true" className="w-full sm:w-auto w-40 text-center px-8 py-5 text-lg border border-white hover:bg-white hover:text-black rounded-full font-semibold transition-transform transform hover:scale-105">
-                  Book a Demo
-                </Link>
+              <div className="flex flex-col sm:flex-row flex-wrap gap-6 justify-center">
+                <a
+                  href="tel:+18884577509"
+                  className="w-full sm:w-auto w-40 text-center px-8 py-5 text-lg bg-blue-600 hover:bg-blue-700 rounded-full font-semibold transition-transform transform hover:scale-105 shadow"
+                >
+                  Call Now for Demo
+                </a>
+                <a
+                  href="sms:+18884577509"
+                  className="w-full sm:w-auto w-40 text-center px-8 py-5 text-lg border border-white hover:bg-white hover:text-black rounded-full font-semibold transition-transform transform hover:scale-105"
+                >
+                  Chat with Our AI Agent
+                </a>
               </div>
             </div>
             <div className="flex-1 flex justify-center mt-10 md:mt-0">


### PR DESCRIPTION
## Summary
- keep Start Now & Book a Demo buttons in the header
- limit hero CTA to Call Now and Chat with AI buttons
- show a single Call Now button across all devices

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684dc62559648333af31cfed7053f2fd